### PR TITLE
simple fixes to adapt to latest rustc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![crate_name = "static"]
 #![deny(missing_docs)]
 #![deny(warnings)]
-#![feature(core, std_misc, path_ext, fs_time)]
+#![feature(std_misc, path_ext, fs_time)]
 
 //! Static file-serving handler.
 

--- a/src/requested_path.rs
+++ b/src/requested_path.rs
@@ -1,14 +1,15 @@
 use iron::Request;
-use std::path::{PathBuf, AsPath};
+use std::path::{PathBuf, Path};
 use std::fs::PathExt;
+use std::convert::AsRef;
 
 pub struct RequestedPath {
     pub path: PathBuf,
 }
 
 impl RequestedPath {
-    pub fn new<P: AsPath>(root_path: P, request: &Request) -> RequestedPath {
-        let mut path = root_path.as_path().to_path_buf();
+    pub fn new<P: AsRef<Path>>(root_path: P, request: &Request) -> RequestedPath {
+        let mut path = root_path.as_ref().to_path_buf();
 
         path.extend(&request.url.path);
 
@@ -17,9 +18,8 @@ impl RequestedPath {
 
     pub fn should_redirect(&self, request: &Request) -> bool {
         let last_url_element = request.url.path
-            .as_slice()
             .last()
-            .map(|s| s.as_slice());
+            .map(|s| s.as_ref());
 
         // As per servo/rust-url/serialize_path, URLs ending in a slash have an
         // empty string stored as the last component of their path. Rust-url


### PR DESCRIPTION
* no longer need the `core` feature.
* use `AsRef<Path>` instead of `AsPath`
* adapted to the new `IfModifiedSince` type definition
* `LastModified` expects an `HttpDate`

As I said on IRC, it builds but the tests don't run because iron-test
fails to build.